### PR TITLE
gegl: add missing dep

### DIFF
--- a/community/gegl/depends
+++ b/community/gegl/depends
@@ -1,4 +1,5 @@
 babl
+json-glib
 bash                  make
 glib
 meson                 make


### PR DESCRIPTION
gegl is missing json-glib as dep.
If its a make dep, please let me know.