### PR TITLE
Explicitly specify DESTDIR when installing

### DIFF
--- a/community/2bwm/build
+++ b/community/2bwm/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/bspwm/build
+++ b/community/bspwm/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/cwm/build
+++ b/community/cwm/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/dmenu/build
+++ b/community/dmenu/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/dragon-git/build
+++ b/community/dragon-git/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/dzen/build
+++ b/community/dzen/build
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
-make -C gadgets PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr -C gadgets  install
 
 install -Dm644 README  "$1/usr/share/doc/dzen/README"
 install -Dm644 CREDITS "$1/usr/share/doc/dzen/CREDITS"

--- a/community/lemonbar/build
+++ b/community/lemonbar/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/nsxiv/build
+++ b/community/nsxiv/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/sent/build
+++ b/community/sent/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/slock-paranoid-git/build
+++ b/community/slock-paranoid-git/build
@@ -2,4 +2,4 @@
 cp twilio_example.h twilio.h
 cp imgur_example.h  imgur.h
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/slock/build
+++ b/community/slock/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/spectrwm/build
+++ b/community/spectrwm/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 cd linux
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/surf/build
+++ b/community/surf/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/svkbd/build
+++ b/community/svkbd/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/sx/build
+++ b/community/sx/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/sxhkd/build
+++ b/community/sxhkd/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/sxiv/build
+++ b/community/sxiv/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/tabbed/build
+++ b/community/tabbed/build
@@ -7,4 +7,4 @@
 patch -p1 < tabbed-0.6-xft.diff
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/vimb-git/build
+++ b/community/vimb-git/build
@@ -13,4 +13,4 @@ sed -E \
 mv -f _ src/config.def.h
 
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/vimb/build
+++ b/community/vimb/build
@@ -13,4 +13,4 @@ sed -E \
 mv -f _ src/setting.c
 
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/wyeb/build
+++ b/community/wyeb/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/xdo/build
+++ b/community/xdo/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make PREFIX=/usr
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/xdotool/build
+++ b/community/xdotool/build
@@ -7,4 +7,4 @@ sed Makefile \
 mv -f _ Makefile
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/xnotify/build
+++ b/community/xnotify/build
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/xrandr-invert-colors/build
+++ b/community/xrandr-invert-colors/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/community/xwm/build
+++ b/community/xwm/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/extra/giflib/build
+++ b/extra/giflib/build
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 
 make
-make PREFIX=/usr install
+make DESTDIR="$1" PREFIX=/usr install

--- a/extra/libdrm/build
+++ b/extra/libdrm/build
@@ -23,4 +23,4 @@ meson \
     . build
 
 ninja -C build
-ninja -C build install
+DESTDIR="$1" ninja -C build install

--- a/xorg/libxcvt/build
+++ b/xorg/libxcvt/build
@@ -5,4 +5,4 @@ meson \
     . output
 
 ninja -C output
-ninja -C output install
+DESTDIR="$1" ninja -C output install

--- a/xorg/xkeyboard-config/build
+++ b/xorg/xkeyboard-config/build
@@ -17,4 +17,4 @@ meson \
     . output
 
 ninja -C output
-ninja -C output install
+DESTDIR="$1" ninja -C output install


### PR DESCRIPTION
Kiss sets DESTDIR in the environment, but is clearer to explicitly pass it
into make.

This patch was mainly generated by

```
find . -type f -name  build -exec sed -E -i 's/make (PREFIX=\/usr)? install/make DESTDIR="$1" \1 install/g' {} \+
```

dzen/build was updated manually.