### PR TITLE
setxkbmap: fix source

### DIFF
--- a/xorg/setxkbmap/sources
+++ b/xorg/setxkbmap/sources
@@ -1,1 +1,1 @@
-../libXmeta/sources-app
+https://x.org/releases/individual/app/PACKAGE-VERSION.tar.xz


### PR DESCRIPTION
unlink libXmeta this for now, util they figure out to put the .bz version back in there.