### PR TITLE
freetype-harfbuzz: drop mesa as dep

### DIFF
--- a/extra/freetype-harfbuzz/depends
+++ b/extra/freetype-harfbuzz/depends
@@ -10,7 +10,6 @@ libdrm
 libpng
 libxcb
 libxshmfence
-mesa
 meson   make
 pixman
 pkgconf make


### PR DESCRIPTION
it seems mesa was listed as a dep for `freetype-harfbuzz`.
mesa is not needed here.
I noticed this when doing a tinyx only build, and noticed it pulled in mesa.
