### PR TITLE
tinyx: make libXdmcp a makedep

### DIFF
--- a/xorg/tinyx/build
+++ b/xorg/tinyx/build
@@ -4,7 +4,9 @@
 
 ./configure \
     --prefix=/usr \
-    --with-fontdir=/usr/share/fonts
+    --with-fontdir=/usr/share/fonts \
+    --disable-xdmcp \
+    --disable-xdb-auth-1 
 
 make
 make install

--- a/xorg/tinyx/build
+++ b/xorg/tinyx/build
@@ -6,7 +6,7 @@
     --prefix=/usr \
     --with-fontdir=/usr/share/fonts \
     --disable-xdmcp \
-    --disable-xdb-auth-1 
+    --disable-xdm-auth-1
 
 make
 make install

--- a/xorg/tinyx/depends
+++ b/xorg/tinyx/depends
@@ -1,5 +1,7 @@
 autoconf make
+automake make
 freetype-harfbuzz
+libXdmcp make
 libXfont
 libXtst
 libfontenc

--- a/xorg/tinyx/depends
+++ b/xorg/tinyx/depends
@@ -1,6 +1,5 @@
 autoconf make
 freetype-harfbuzz
-libXdmcp
 libXfont
 libXtst
 libfontenc

--- a/xorg/tinyx/depends
+++ b/xorg/tinyx/depends
@@ -7,4 +7,6 @@ libXtst
 libfontenc
 libpng
 libtool make
+linux-headers make
+pkgconf make
 xtrans


### PR DESCRIPTION
it seems we can simply disable the usabe of libXdmcp.

might need some more testing.
perhaps @kyx0r has some input on this.

on my end it does seem to work fine.

If theres no issue, Ill add the removal of `libXdmcp` in this PR aswell, as nothing else needs it.
