### PR TITLE
xdotool: rm man, static linking

### DIFF
--- a/community/xdotool/build
+++ b/community/xdotool/build
@@ -2,12 +2,11 @@
 
 export DESTDIR="$1"
 
-
 # Remove compiler debug stuff and post-install message.
 sed Makefile \
     -e '/CFLAGS.*-g/d' \
     -e '/^install:/s/ post-install$//' > _
 mv -f _ Makefile
 
-make
-make PREFIX=/usr install
+make xdotool.static
+make PREFIX=/usr install-static

--- a/community/xdotool/depends
+++ b/community/xdotool/depends
@@ -6,4 +6,3 @@ libXinerama
 libXtst
 libxcb
 libxkbcommon
-perl make


### PR DESCRIPTION
xdotool requires libxdo library to exist on the system for it to function, this will remove the need for that and remove man pages, which remove the need for perl.