### PR TITLE
webkit2gtk: remove need for lcms

### DIFF
--- a/community/webkit2gtk/build
+++ b/community/webkit2gtk/build
@@ -87,6 +87,7 @@ cmake -B build \
     -DENABLE_WEB_AUDIO="${streaming:-OFF}" \
     -DENABLE_GAMEPAD=OFF \
     -DENABLE_JOURNALD_LOG=OFF \
+    -DUSE_LCMS=OFF \
     -Wno-dev
 
 cmake --build build

--- a/community/webkit2gtk/depends
+++ b/community/webkit2gtk/depends
@@ -5,7 +5,6 @@ glib-networking
 gperf  make
 gtk+3
 harfbuzz-icu
-lcms
 libXt
 libgcrypt
 libsoup


### PR DESCRIPTION
lcms can be disabled, and therefore not needed to build webkit