### PR TITLE
mark xorg-util-macros as make dep

### DIFF
--- a/xorg/libxcb/depends
+++ b/xorg/libxcb/depends
@@ -1,5 +1,5 @@
 libXau
-pkgconf make
-python  make
+pkgconf          make
+python           make
 xcb-proto
-xorg-util-macros
+xorg-util-macros make

--- a/xorg/libxcvt/depends
+++ b/xorg/libxcvt/depends
@@ -1,7 +1,6 @@
 libXau
-meson   make
-pkgconf make
-python  make
-samurai make
+meson            make
+pkgconf          make
+python           make
 xcb-proto
-xorg-util-macros
+xorg-util-macros make


### PR DESCRIPTION
```
$ kiss reporevdep xorg-util-macros
kiss-xorg/xorg/libXmu/depends:xorg-util-macros make
kiss-xorg/xorg/libXpm/depends:xorg-util-macros make
kiss-xorg/xorg/libxcb/depends:xorg-util-macros
kiss-xorg/xorg/libxcvt/depends:xorg-util-macros
kiss-xorg/xorg/mkfontscale/depends:xorg-util-macros make
kiss-xorg/xorg/xauth/depends:xorg-util-macros make
kiss-xorg/xorg/xbitmaps/depends:xorg-util-macros make
kiss-xorg/xorg/xdpyinfo/depends:xorg-util-macros make
kiss-xorg/xorg/xev/depends:xorg-util-macros make
kiss-xorg/xorg/xf86-video-ati/depends:xorg-util-macros
kiss-xorg/xorg/xf86-video-vesa/depends:xorg-util-macros make
kiss-xorg/xorg/xorg-font-util/depends:xorg-util-macros make
kiss-xorg/xorg/xrandr/depends:xorg-util-macros make
kiss-xorg/xorg/xrdb/depends:xorg-util-macros make
kiss-xorg/xorg/xset/depends:xorg-util-macros make
kiss-xorg/xorg/xwininfo/depends:xorg-util-macros make
kiss-xorg/community/xcb-util-xrm/depends:xorg-util-macros make
kiss-xorg/community/xf86-video-qxl/depends:xorg-util-macros make
```